### PR TITLE
fix Highway layer bug

### DIFF
--- a/sogou_mrc/model/qanet.py
+++ b/sogou_mrc/model/qanet.py
@@ -78,7 +78,8 @@ class QANET(BaseModel):
 
         char_cnn = Conv1DAndMaxPooling(self.char_filters,self.kernel_size1,padding='same',activation=tf.nn.relu)
         embedding_dense = tf.keras.layers.Dense(self.filters)
-        highway = Highway(gate_activation=tf.nn.relu,trans_activation=tf.nn.tanh,hidden_units=self.filters,keep_prob=self.keep_prob)
+        highway = Highway(affine_activation=tf.nn.relu, trans_gate_activation=tf.nn.sigmoid,
+                          hidden_units=self.filters, keep_prob=self.keep_prob)
 
         context_char_repr = tf.reshape(char_cnn(context_char_embedding),[-1,max_context_len,self.char_filters]) # B*CL*CF
         context_repr = highway(dropout(embedding_dense(tf.concat([context_word_embedding,context_char_repr],-1)), self.training),self.training) # B*CL*F

--- a/sogou_mrc/nn/layers.py
+++ b/sogou_mrc/nn/layers.py
@@ -21,26 +21,31 @@ class Layer(object):
 
 
 class Highway(Layer):
-    def __init__(self, gate_activation=tf.nn.relu,trans_activation=tf.nn.sigmoid,hidden_units=0,keep_prob=1.0,name="highway"):
+    def __init__(self,
+                 affine_activation=tf.nn.relu,
+                 trans_gate_activation=tf.nn.sigmoid,
+                 hidden_units=0,
+                 keep_prob=1.0,
+                 name="highway"):
         super(Highway, self).__init__(name)
 
-        self.gate_activation = gate_activation
-        self.trans_activation = trans_activation
-        self.gate_layer = None
-        self.trans_layer = None
+        self.affine_activation = affine_activation
+        self.trans_gate_activation = trans_gate_activation
+        self.affine_layer = None
+        self.trans_gate_layer = None
         self.dropout = Dropout(keep_prob)
         if hidden_units > 0:
-            self.gate_layer = tf.keras.layers.Dense(hidden_units, activation=self.gate_activation)
-            self.trans_layer = tf.keras.layers.Dense(hidden_units, activation=self.trans_activation)
+            self.affine_layer = tf.keras.layers.Dense(hidden_units, activation=self.affine_activation)
+            self.trans_gate_layer = tf.keras.layers.Dense(hidden_units, activation=self.trans_gate_activation)
 
     def __call__(self, x, training=True):
-        if self.gate_layer is None:
+        if self.trans_gate_layer is None:
             hidden_units = x.shape.as_list()[-1]
-            self.gate_layer = tf.keras.layers.Dense(hidden_units, activation=self.gate_activation)
-            self.trans_layer = tf.keras.layers.Dense(hidden_units, activation=self.trans_activation)
+            self.affine_layer = tf.keras.layers.Dense(hidden_units, activation=self.affine_activation)
+            self.trans_gate_layer = tf.keras.layers.Dense(hidden_units, activation=self.trans_gate_activation)
 
-        gate = self.gate_layer(x)
-        trans = self.dropout(self.trans_layer(x), training=training)
+        gate = self.trans_gate_layer(x)
+        trans = self.dropout(self.affine_layer(x), training=training)
         return gate * trans + (1. - gate) * x
 
 


### PR DESCRIPTION
In the original paper of [Highway Networks](https://arxiv.org/abs/1505.00387), the output of the highway layer is `y=H(x,WH)·T(x,WT)+x·(1−T(x,WT))`, and:

> For highway layers, we use the transform gate defined as `T (x) = σ(Wx + b)`, where WT is the weight matrix and bT the bias vector for the transform gates.

So, the activation of the transform gate is `sigmoid`, and the activation of the affine transform layer is a non-linear activation function, like relu. [The highway code in this repo](https://github.com/sogou/SMRCToolkit/blob/b40b30aa8401b955c03bf024eb859f3c78182c8b/sogou_mrc/nn/layers.py#L24) is just reversed. So I create a pull request to fixed it.

Thanks.